### PR TITLE
only sends one email when registering

### DIFF
--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -51,7 +51,6 @@ class Users::RegistrationsController < Devise::RegistrationsController
     @user = User.new configure_sign_up_params
     @user.role = 'user'
     if @user.save
-      UserMailer.with(user: @user).new_registration.deliver_now
       redirect_to root_path, notice: 'Success! Check your email to confirm your account'
     else
       redirect_to root_path, notice: 'User cannot be added'

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -10,13 +10,8 @@ class User < ApplicationRecord
   has_many :logs, dependent: :destroy
 
   before_create :set_default_role, :set_default_status
-  after_create :send_email_confirmation
 # email notification
   
-  def send_email_confirmation
-    UserMailer.with(user: self).new_registration.deliver_now
-  end
-
   def set_default_role
     self.role ||= :user
   end


### PR DESCRIPTION
This PR removes the callback to send a welcome email so that we only send one when a user signs up.